### PR TITLE
New placeholder and changes to 2 existent placeholders!

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,26 +3,27 @@ plugins {
 }
 
 group = "me.thienbao860"
-version = "1.2.3"
+version = "1.2.4"
 
 repositories {
     mavenCentral()
 
-    maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
+    maven("https://repo.papermc.io/repository/maven-public/")
     maven("https://repo.extendedclip.com/releases/")
     maven("https://jitpack.io")
 }
 
 dependencies {
-    compileOnly("org.spigotmc:spigot-api:+")
+    compileOnly("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
     compileOnly("me.clip:placeholderapi:2.11.6")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
 }
 
 tasks {
     java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
+        disableAutoTargetJvm()
         targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
 
         withJavadocJar()
         withSourcesJar()

--- a/src/main/java/me/thienbao860/expansion/world/WorldExpansion.java
+++ b/src/main/java/me/thienbao860/expansion/world/WorldExpansion.java
@@ -154,14 +154,14 @@ public class WorldExpansion extends PlaceholderExpansion implements Listener, Ca
 
                 switch (args[1]) {
                     case "entities":
-                        return getFromCache("totalEntities", () -> world.getEntities().size());
+                        return getFromCache("totalEntities" + world.getName(), () -> world.getEntities().size());
                     case "living":
                         if (args.length < 4 || !args[2].equals("living")) {
                             return null;
                         }
-                        return getFromCache("totalLivingEntities", () -> world.getLivingEntities().size());
+                        return getFromCache("totalLivingEntities" + world.getName(), () -> world.getLivingEntities().size());
                     case "chunks":
-                        return getFromCache("totalChunks", () -> world.getLoadedChunks().length);
+                        return getFromCache("totalChunks" + world.getName(), () -> world.getLoadedChunks().length);
                 }
 
             case "players":


### PR DESCRIPTION
I've added the following placeholder:

```yml
- %world_total_chunks_<world>%       # Gets the loaded chunks count in a world
```

I've also made some changes to existent placeholders to better align them with the Server placeholders:

```yml
- %world_entities_<world>%           -->  %world_total_entities_<world>%
- %world_entities_living_<world>%    -->  %world_total_living_entities_<world>%
```

Also, the values of `total` placeholders (the 3 mentioned above), are now cached for 1 minute. This is also aligned with the Server expansion which does the same.